### PR TITLE
Add orchestrated search to paper improver

### DIFF
--- a/ai_scientist/paper_improver/__init__.py
+++ b/ai_scientist/paper_improver/__init__.py
@@ -1,0 +1,4 @@
+"""Paper-improver public API."""
+from .pipeline import improve_paper  # re-export for convenience
+
+__all__ = ["improve_paper"]

--- a/ai_scientist/paper_improver/latex_editor.py
+++ b/ai_scientist/paper_improver/latex_editor.py
@@ -1,0 +1,44 @@
+"""Generate and apply edit proposals to LaTeX source using an LLM."""
+from pathlib import Path
+from ai_scientist.llm import create_client
+from ai_scientist.utils.token_tracker import track_token_usage
+
+EDITOR_MODEL = "o1-preview-2024-09-12"
+
+
+@track_token_usage
+def propose_edit(
+    latex_path: Path,
+    seed_ideas: str,
+    human_reviews: str | None = None,
+    model: str = EDITOR_MODEL,
+) -> str:
+    """Return *new* LaTeX code after applying improvements suggested by the model."""
+    prompt = f"""You are an expert academic writing assistant.  Below is the current LaTeX paper, a set of human reviews, and high-level improvement ideas.
+Improve the document **in place** focusing on clarity, scientific rigour, and addressing reviewers’ concerns.  Output *only* the updated LaTeX in a fenced ```latex block.
+
+############  CURRENT LaTeX ############
+{latex_path.read_text()}
+########################################
+
+############ HUMAN REVIEWS ############
+{human_reviews or 'N/A'}
+########################################
+
+############  SEED IDEAS   ############
+{seed_ideas}
+########################################
+"""
+    client, m = create_client(model)
+    resp = client.chat.completions.create(
+        model=m,
+        messages=[{"role": "user", "content": prompt}],
+        temperature=0.4,
+    )
+    # Extract LaTeX from fenced block – simple heuristic
+    import re, textwrap
+    code = re.search(r"```latex(.*)```", resp.choices[0].message.content, re.DOTALL)
+    if not code:
+        raise ValueError("No LaTeX block returned by editor model")
+    new_source = textwrap.dedent(code.group(1)).strip()
+    return new_source

--- a/ai_scientist/paper_improver/llm_review.py
+++ b/ai_scientist/paper_improver/llm_review.py
@@ -1,0 +1,21 @@
+"""LLM-only review wrapper."""
+from typing import Any
+from ai_scientist.perform_llm_review import perform_review  # existing util
+from ai_scientist.llm import create_client
+
+DEFAULT_MODEL = "gpt-4o-2024-11-20"
+
+
+def llm_review(tex_or_pdf_path: str, *, model: str = DEFAULT_MODEL, **kwargs) -> dict[str, Any]:
+    """Run the standard LLM review and return the parsed JSON.
+
+    Parameters
+    ----------
+    tex_or_pdf_path
+        Path to the LaTeX source (compiled) *or* an already-built PDF.
+    model
+        LLM to use for the review phase.
+    """
+    client, m = create_client(model)
+    review_json = perform_review(tex_or_pdf_path, m, client, **kwargs)
+    return review_json

--- a/ai_scientist/paper_improver/meta_review.py
+++ b/ai_scientist/paper_improver/meta_review.py
@@ -1,0 +1,34 @@
+"""Combine multiple review JSONs into a single numerical score."""
+from __future__ import annotations
+from statistics import mean
+from typing import Sequence, Dict, Any
+
+DEFAULT_WEIGHTS = {
+    "Originality": 3,
+    "Quality": 3,
+    "Clarity": 2,
+    "Significance": 4,
+    "Overall": 5,  # emphasise overall judgement
+}
+
+
+def score_single(review_json: Dict[str, Any], weights: Dict[str, int] | None = None) -> float:
+    """Weighted average of key fields (1-10 scaled to 1-4 where needed)."""
+    if weights is None:
+        weights = DEFAULT_WEIGHTS
+    total, denom = 0.0, 0.0
+    for k, w in weights.items():
+        val = review_json.get(k)
+        if val is None:
+            continue
+        # normalise different scales
+        if k == "Overall":
+            val = val / 2.5  # map 1-10 → ~0-4
+        total += w * float(val)
+        denom += w
+    return total / denom if denom else 0.0
+
+
+def meta_score(reviews: Sequence[Dict[str, Any]]) -> float:
+    """Average score over a set of reviews."""
+    return mean(score_single(r) for r in reviews) if reviews else 0.0

--- a/ai_scientist/paper_improver/pipeline.py
+++ b/ai_scientist/paper_improver/pipeline.py
@@ -1,0 +1,23 @@
+"""High-level orchestration: given inputs, run the improver search."""
+from pathlib import Path
+from .search import breadth_first_improve, tree_search_improve
+
+
+def improve_paper(
+    latex_project_dir: str | Path,
+    seed_ideas: str,
+    human_reviews: str | None = None,
+    strategy: str = "bfs",
+    **kwargs,
+):
+    root = Path(latex_project_dir).resolve()
+    if strategy == "tree":
+        best_state, _journal = tree_search_improve(
+            root, seed_ideas, human_reviews, **kwargs
+        )
+    else:
+        best_state, _journal = breadth_first_improve(
+            root, seed_ideas, human_reviews, **kwargs
+        )
+    print("Best improved paper saved at", best_state.latex_dir)
+    return best_state

--- a/ai_scientist/paper_improver/search.py
+++ b/ai_scientist/paper_improver/search.py
@@ -1,0 +1,181 @@
+"""Breadth-First Tree Search (BFTS) over paper versions."""
+from __future__ import annotations
+
+from collections import deque
+import heapq
+import uuid
+from pathlib import Path
+import shutil, json
+from ai_scientist.treesearch.backend import query, FunctionSpec
+from .latex_editor import propose_edit
+from .llm_review import llm_review
+from .vlm_review import vlm_review
+from .meta_review import meta_score
+
+ORCHESTRATOR_MODEL = "gpt-4o-2024-11-20"
+
+node_selection_spec = FunctionSpec(
+    name="select_best_implementation",
+    description="Select the best implementation based on comprehensive analysis",
+    json_schema={
+        "type": "object",
+        "properties": {
+            "selected_id": {
+                "type": "string",
+                "description": "ID of the selected best implementation",
+            },
+            "reasoning": {
+                "type": "string",
+                "description": "Detailed explanation of why this implementation was chosen",
+            },
+        },
+        "required": ["selected_id", "reasoning"],
+    },
+)
+
+
+class PaperNode:
+    """A paper version on disk (latex_dir contains template.tex)."""
+
+    def __init__(self, latex_dir: Path, depth: int = 0, parent: "PaperNode | None" = None):
+        self.id = uuid.uuid4().hex
+        self.latex_dir = latex_dir
+        self.depth = depth
+        self.parent = parent
+        self.children: list["PaperNode"] = []
+        self.pdf_path = latex_dir / "template.pdf"  # compiled later
+        self.score: float | None = None
+        self.llm_json: dict | None = None
+        self.vlm_json: dict | None = None
+        # compatibility with treesearch Journal
+        self.is_buggy = False
+        self.is_buggy_plots = False
+
+    def compile(self):
+        from ai_scientist.perform_icbinb_writeup import compile_latex  # reuse util
+
+        compile_latex(str(self.latex_dir), str(self.pdf_path))
+
+    def evaluate(self):
+        if not self.pdf_path.exists():
+            self.compile()
+        self.llm_json = llm_review(str(self.pdf_path))
+        self.vlm_json = vlm_review(str(self.pdf_path))
+        self.score = meta_score([self.llm_json, self.vlm_json])
+        # Persist results for analysis
+        with open(self.latex_dir / "reviews.json", "w") as f:
+            json.dump({"llm": self.llm_json, "vlm": self.vlm_json, "score": self.score}, f, indent=2)
+        return self.score
+
+
+class Journal:
+    """Keep track of explored paper versions."""
+
+    def __init__(self) -> None:
+        self.nodes: list[PaperNode] = []
+
+    def append(self, node: PaperNode) -> None:
+        node.step = len(self.nodes)
+        self.nodes.append(node)
+
+    def best_node(self) -> PaperNode | None:
+        if not self.nodes:
+            return None
+        if len(self.nodes) == 1:
+            return self.nodes[0]
+
+        prompt = {
+            "Introduction": (
+                "You are an experienced researcher choosing the best improved paper version based on review scores."
+            ),
+            "Candidates": "",
+        }
+        for n in self.nodes:
+            prompt["Candidates"] += f"ID: {n.id} Score: {n.score:.3f}\n"
+
+        try:
+            selection = query(
+                system_message=prompt,
+                user_message=None,
+                func_spec=node_selection_spec,
+                model=ORCHESTRATOR_MODEL,
+                temperature=0.3,
+            )
+            selected = next((n for n in self.nodes if n.id == selection["selected_id"]), None)
+            if selected:
+                return selected
+        except Exception:
+            pass
+        return max(self.nodes, key=lambda n: n.score or 0)
+
+
+def breadth_first_improve(
+    root_dir: Path,
+    seed_ideas: str,
+    human_reviews: str | None = None,
+    max_depth: int = 3,
+    beam_size: int = 4,
+):
+    """Explore paper edits using best-first strategy."""
+    root = PaperNode(root_dir)
+    root.evaluate()
+    journal = Journal()
+    journal.append(root)
+    frontier = deque([root])
+    best_state = root
+    while frontier:
+        state = frontier.popleft()
+        print(f"Evaluating depth={state.depth} dir={state.latex_dir}")
+        score = state.score if state is root else state.evaluate()
+        if score > best_state.score:
+            best_state = state
+            print(f"[NEW BEST] score={score:.3f} at {state.latex_dir}")
+        if state.depth >= max_depth:
+            continue
+        # Expand children by proposing edits
+        for i in range(beam_size):
+            child_dir = state.latex_dir.parent / f"child_d{state.depth}_{i}"
+            shutil.copytree(state.latex_dir, child_dir, dirs_exist_ok=True)
+            tex_path = child_dir / "template.tex"
+            new_source = propose_edit(tex_path, seed_ideas, human_reviews)
+            tex_path.write_text(new_source)
+            child = PaperNode(child_dir, state.depth + 1, parent=state)
+            state.children.append(child)
+            journal.append(child)
+            frontier.append(child)
+    return journal.best_node(), journal
+
+
+def tree_search_improve(
+    root_dir: Path,
+    seed_ideas: str,
+    human_reviews: str | None = None,
+    max_depth: int = 3,
+    beam_size: int = 4,
+):
+    """Priority-based tree search over paper versions."""
+    root = PaperNode(root_dir)
+    root.evaluate()
+    journal = Journal()
+    journal.append(root)
+    frontier: list[tuple[float, PaperNode]] = [(-root.score, root)]
+
+    while frontier:
+        _, node = heapq.heappop(frontier)
+        print(f"Exploring depth={node.depth} dir={node.latex_dir} score={node.score:.3f}")
+        if node.depth >= max_depth:
+            continue
+        for i in range(beam_size):
+            child_dir = node.latex_dir.parent / f"node_d{node.depth}_{i}"
+            shutil.copytree(node.latex_dir, child_dir, dirs_exist_ok=True)
+            tex_path = child_dir / "template.tex"
+            new_source = propose_edit(tex_path, seed_ideas, human_reviews)
+            tex_path.write_text(new_source)
+            child = PaperNode(child_dir, node.depth + 1, parent=node)
+            node.children.append(child)
+            child.evaluate()
+            journal.append(child)
+            heapq.heappush(frontier, (-child.score, child))
+
+    return journal.best_node(), journal
+

--- a/ai_scientist/paper_improver/utils.py
+++ b/ai_scientist/paper_improver/utils.py
@@ -1,0 +1,3 @@
+"""Helper utilities for the paper_improver package."""
+
+# Placeholder for shared helper functions. None are defined yet.

--- a/ai_scientist/paper_improver/vlm_review.py
+++ b/ai_scientist/paper_improver/vlm_review.py
@@ -1,0 +1,11 @@
+"""Figure-centric VLM review wrapper."""
+from pathlib import Path
+from ai_scientist.perform_vlm_review import perform_imgs_cap_ref_review
+from ai_scientist.vlm import create_client as create_vlm_client
+
+VLM_MODEL = "gpt-4o-2024-11-20"
+
+
+def vlm_review(pdf_path: str) -> dict:
+    client, model = create_vlm_client(VLM_MODEL)
+    return perform_imgs_cap_ref_review(client, model, pdf_path)

--- a/scripts/launch_paper_improver.py
+++ b/scripts/launch_paper_improver.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""CLI for the paper improver."""
+import argparse, json
+from pathlib import Path
+from ai_scientist.paper_improver import improve_paper
+
+parser = argparse.ArgumentParser(description="Iteratively improve an existing paper via AI-Scientist pipeline")
+parser.add_argument("latex_dir", help="Directory containing template.tex (and figures)")
+parser.add_argument("seed_ideas_json", help="JSON file with high-level improvement ideas")
+parser.add_argument("--human-reviews", help="Path to txt/markdown file with reviewer comments")
+parser.add_argument("--max-depth", type=int, default=2)
+parser.add_argument("--beam-size", type=int, default=3)
+parser.add_argument(
+    "--strategy",
+    choices=["bfs", "tree"],
+    default="bfs",
+    help="Search strategy to use: simple bfs or priority tree search",
+)
+args = parser.parse_args()
+
+seed_ideas = json.loads(Path(args.seed_ideas_json).read_text())
+human_reviews = Path(args.human_reviews).read_text() if args.human_reviews else None
+
+improve_paper(
+    args.latex_dir,
+    json.dumps(seed_ideas, indent=2),
+    human_reviews,
+    max_depth=args.max_depth,
+    beam_size=args.beam_size,
+    strategy=args.strategy,
+)


### PR DESCRIPTION
## Summary
- add OpenAI-based orchestrator in paper improver search
- keep BFS and tree search modes but both track nodes in a journal
- expose orchestrated selection in pipeline

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68431326f0a88331912ecc7df1ad94f3